### PR TITLE
Add 'memmem' as a Cargo keyword.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT/Apache-2.0"
 repository = "https://github.com/bluss/twoway"
 documentation = "https://docs.rs/twoway/"
 
-keywords = ["substring-search", "string", "pcmpestri", "find", "no_std"]
+keywords = ["substring-search", "string", "pcmpestri", "find", "memmem"]
 categories = ["algorithms", "no-std"]
 
 [dependencies]


### PR DESCRIPTION
This algorithm is commonly used to implement memmem because it's very
efficient, so let's make it easier to find for those users who don't
know what algorithm they want.

It took me a bit of searching to find this for my needs; this keyword would have made it much quicker.