### PR TITLE
Factor out critical parameters computations

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -433,15 +433,7 @@ pub struct TwoWaySearcher {
 */
 impl TwoWaySearcher {
     pub fn new(needle: &[u8], end: usize) -> TwoWaySearcher {
-        let (crit_pos_false, period_false) = TwoWaySearcher::maximal_suffix(needle, false);
-        let (crit_pos_true, period_true) = TwoWaySearcher::maximal_suffix(needle, true);
-
-        let (crit_pos, period) =
-            if crit_pos_false > crit_pos_true {
-                (crit_pos_false, period_false)
-            } else {
-                (crit_pos_true, period_true)
-            };
+        let (crit_pos, period) = TwoWaySearcher::crit_params(needle);
 
         // A particularly readable explanation of what's going on here can be found
         // in Crochemore and Rytter's book "Text Algorithms", ch 13. Specifically
@@ -496,6 +488,22 @@ impl TwoWaySearcher {
                 memory: usize::MAX, // Dummy value to signify that the period is long
                 memory_back: usize::MAX,
             }
+        }
+    }
+
+    /// Return the zero-based critical position and period of the provided needle.
+    /// 
+    /// The returned period is incorrect when the actual period is "long." In
+    /// that case the approximation must be computed separately.
+    #[inline(always)]
+    fn crit_params(needle: &[u8]) -> (usize, usize) {
+        let (crit_pos_false, period_false) = TwoWaySearcher::maximal_suffix(needle, false);
+        let (crit_pos_true, period_true) = TwoWaySearcher::maximal_suffix(needle, true);
+
+        if crit_pos_false > crit_pos_true {
+            (crit_pos_false, period_false)
+        } else {
+            (crit_pos_true, period_true)
         }
     }
 

--- a/src/pcmp.rs
+++ b/src/pcmp.rs
@@ -103,22 +103,6 @@ unsafe fn pcmpestrm_eq_each(text: *const u8, offset: usize, text_len: usize,
 }
 
 
-/// Return critical position, period.
-/// critical position is zero-based
-///
-/// Note: If the period is long, the correct period is not returned.
-/// The approximation to a long period must be computed separately.
-#[inline(never)]
-fn crit_period(pat: &[u8]) -> (usize, usize) {
-    let (i, p) = TwoWaySearcher::maximal_suffix(pat, false);
-    let (j, q) = TwoWaySearcher::maximal_suffix(pat, true);
-    if i >= j {
-        (i, p)
-    } else {
-        (j, q)
-    }
-}
-
 /// Search for first possible match of `pat` -- might be just a byte
 /// Return `(pos, length)` length of match
 #[cfg(test)]
@@ -347,7 +331,7 @@ pub fn find(text: &[u8], pattern: &[u8]) -> Option<usize> {
     //
 
     // `memory` is the number of bytes of the left half that we already know
-    let (crit_pos, mut period) = crit_period(pat);
+    let (crit_pos, mut period) = TwoWaySearcher::crit_params(pat);
     let mut memory;
 
     if &pat[..crit_pos] == &pat[period.. period + crit_pos] {


### PR DESCRIPTION
It's used by both the SSE42 and regular implementations, so we can avoid some duplication.

I'm not sure if the difference in inlining is significant- the new one is inline(always) whereas is was explicitly inlined in one and never inlined in the other. It seems like there's no harm in that change, since in either case the actual `find` function isn't marked inlineable.