### PR TITLE
Expose TwoWaySearcher's next and next_back functions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -536,7 +536,7 @@ impl TwoWaySearcher {
     // How far we can jump when we encounter a mismatch is all based on the fact
     // that (u, v) is a critical factorization for the needle.
     #[inline(always)]
-    fn next<S>(&mut self, haystack: &[u8], needle: &[u8], long_period: bool)
+    pub fn next<S>(&mut self, haystack: &[u8], needle: &[u8], long_period: bool)
         -> S::Output
         where S: TwoWayStrategy
     {
@@ -619,7 +619,7 @@ impl TwoWaySearcher {
     // To search in reverse through the haystack, we search forward through
     // a reversed haystack with a reversed needle, matching first u' and then v'.
     #[inline]
-    fn next_back<S>(&mut self, haystack: &[u8], needle: &[u8], long_period: bool)
+    pub fn next_back<S>(&mut self, haystack: &[u8], needle: &[u8], long_period: bool)
         -> S::Output
         where S: TwoWayStrategy
     {


### PR DESCRIPTION
Handles #10  as the minimum required to use `TwoWaySearcher` in a `Searcher` impl.

There is some ability for API misuse here since `new` takes a needle, but doesn't save it meaning `next` and `next_back` need to be given the same needle again to work correctly. It may be worth storing the needle in the searcher, but this would require a lifetime to be added.